### PR TITLE
Command line bug in ReroutePlugin.php

### DIFF
--- a/reroute/ReroutePlugin.php
+++ b/reroute/ReroutePlugin.php
@@ -38,7 +38,7 @@ class ReroutePlugin extends BasePlugin
 	}
 
 	public function init() {
-		if(craft()->request->isSiteRequest()) {
+		if (!craft()->isConsole() && craft()->request->isSiteRequest()) {
 			$url = craft()->request->getUrl();
 			$reroute = craft()->reroute->getByUrl($url);
 


### PR DESCRIPTION
craft()->request was failing when running a deployment from the command line, since there was no request object. I added a check to make sure it isn't being run when the init is called from the command line.